### PR TITLE
Fix network implementation per README

### DIFF
--- a/models/encoder.py
+++ b/models/encoder.py
@@ -62,8 +62,8 @@ class EncoderBackbone(nn.Module):
         # Module 3: stride=2 (累计stride=8)  
         self.module3 = EncoderModule(base_channels * 2, base_channels * 4, stride=2)
         
-        # Module 4: stride=2 (累计stride=16)
-        self.module4 = EncoderModule(base_channels * 4, base_channels * 8, stride=2)
+        # Module 4: stride=1 (保持stride=16)
+        self.module4 = EncoderModule(base_channels * 4, base_channels * 8, stride=1)
         
         self.base_channels = base_channels
         


### PR DESCRIPTION
## Summary
- keep encoder stride 16 by removing downsampling in last block
- upsample decoder outputs to input resolution
- maintain feedback loop between iterations

## Testing
- `python -m py_compile models/*.py`
- *(attempted `python test_model.py`, but torch installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_688034d1b3608332ba24022590a84052