### PR TITLE
Fix feedback pass and URM default mask

### DIFF
--- a/models/urm.py
+++ b/models/urm.py
@@ -79,6 +79,7 @@ class UncertaintyRectifierModule(nn.Module):
         entropy = self.compute_entropy(logits)
         
         # 3. 生成错误掩码和注意力
+        error_mask = None
         if training and ground_truth is not None:
             # 训练时：使用真值生成错误掩码
             error_mask = self.generate_error_mask(predicted_mask, ground_truth)


### PR DESCRIPTION
## Summary
- handle prototype dicts in MSCFE blocks
- initialize `error_mask` in URM
- run test script (fails without torch)

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test_model.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68803a76cafc8332996221bd0957d0b9